### PR TITLE
По умолчанию выводятся все маршуты текущего приложения.

### DIFF
--- a/controllers/RouteController.php
+++ b/controllers/RouteController.php
@@ -12,9 +12,31 @@ use yii\filters\VerbFilter;
  *
  * @author Misbahul D Munir <misbahuldmunir@gmail.com>
  * @since 1.0
+ *
+ *
+ * in config
+ * $config = yii\helpers\ArrayHelper::merge(
+ *  require(Yii::getAlias('@common') . '/config/main.php'),
+ *  require(Yii::getAlias('@common') . '/config/main-local.php'),
+ *  require(Yii::getAlias('@frontend') . '/config/main.php'),
+ *  require(Yii::getAlias('@frontend') . '/config/main-local.php')
+ * );
+ * ...
+ * 'controllerMap' => [
+ * ...
+ *  'route' => [
+ *  'class' => 'mdm\admin\controllers\RouteController',
+ *  'appModule' =>  new yii\web\Application($config),
+ *  ],
+ * ...
+ * ],
+ * ```
  */
 class RouteController extends Controller
 {
+    /** @type null|string|\yii\web\Application */
+    public $appModule = null;
+
     /**
      * @inheritdoc
      */
@@ -41,7 +63,7 @@ class RouteController extends Controller
     {
         $model = new Route();
 
-        return $this->render('index', ['routes' => $model->getRoutes()]);
+        return $this->render('index', ['routes' => $model->getRoutes($this->appModule)]);
     }
 
     /**
@@ -57,7 +79,7 @@ class RouteController extends Controller
         $model = new Route();
         $model->addNew($routes);
 
-        return $model->getRoutes();
+        return $model->getRoutes($this->appModule);
     }
 
     /**
@@ -71,7 +93,7 @@ class RouteController extends Controller
         $model->addNew($routes);
         Yii::$app->getResponse()->format = 'json';
 
-        return $model->getRoutes();
+        return $model->getRoutes($this->appModule);
     }
 
     /**
@@ -85,7 +107,7 @@ class RouteController extends Controller
         $model->remove($routes);
         Yii::$app->getResponse()->format = 'json';
 
-        return $model->getRoutes();
+        return $model->getRoutes($this->appModule);
     }
 
     /**
@@ -98,6 +120,6 @@ class RouteController extends Controller
         $model->invalidate();
         Yii::$app->getResponse()->format = 'json';
 
-        return $model->getRoutes();
+        return $model->getRoutes($this->appModule);
     }
 }

--- a/models/Route.php
+++ b/models/Route.php
@@ -79,12 +79,13 @@ class Route extends Object
 
     /**
      * Get avaliable and assigned routes
+     * @param null|string|\yii\web\Application $module
      * @return array
      */
-    public function getRoutes()
+    public function getRoutes($module = null)
     {
         $manager = Yii::$app->getAuthManager();
-        $routes = $this->getAppRoutes();
+        $routes = $this->getAppRoutes($module);
         $exists = [];
         foreach (array_keys($manager->getPermissions()) as $name) {
             if ($name[0] !== '/') {
@@ -101,7 +102,7 @@ class Route extends Object
 
     /**
      * Get list of application routes
-     * @param null $module
+     * @param null|string||\yii\web\Application $module
      * @return array|mixed
      */
     public function getAppRoutes($module = null)


### PR DESCRIPTION
А что если мы работаем в админке, а нужно вывести маршруты на клиенте?

Можно переопределить конфиг подключения модуля rbac:
$config = yii\helpers\ArrayHelper::merge(
    require(Yii::getAlias('@common') . '/config/main.php'),
    require(Yii::getAlias('@common') . '/config/main-local.php'),
    require(Yii::getAlias('@frontend') . '/config/main.php'),
    require(Yii::getAlias('@frontend') . '/config/main-local.php')
);
...
'controllerMap' => [
    ...
    'route' => [
        'class' => 'mdm\admin\controllers\RouteController',
        'appModule' =>  new yii\web\Application($config),
    ],
    ...
 ],

 В параметр appModule передаем "объект приложения" для которого нужно вывести маршруты
